### PR TITLE
Fixing documentation generation

### DIFF
--- a/src/SMTLib1.hs
+++ b/src/SMTLib1.hs
@@ -1,5 +1,8 @@
-module SMTLib1 (module X) where
+module SMTLib1 (
+    module SMTLib1.AST,
+    module SMTLib1.PP
+  ) where
 
-import SMTLib1.AST as X
-import SMTLib1.PP as X
+import SMTLib1.AST
+import SMTLib1.PP
 

--- a/src/SMTLib2.hs
+++ b/src/SMTLib2.hs
@@ -1,5 +1,8 @@
-module SMTLib2 (module X) where
+module SMTLib2 (
+    module SMTLib2.AST,
+    module SMTLib2.PP
+  ) where
 
-import SMTLib2.AST as X
-import SMTLib2.PP as X
+import SMTLib2.AST
+import SMTLib2.PP
 


### PR DESCRIPTION
Currently, Haddock generates no documentation for the main files in this library. With this tweak, it will.
