### PR TITLE
Add CmdComment for representing comments in scripts.

### DIFF
--- a/src/SMTLib2/AST.hs
+++ b/src/SMTLib2/AST.hs
@@ -93,6 +93,7 @@ data Command
   | CmdGetUnsatCore
   | CmdGetInfo InfoFlag
   | CmdGetOption Name
+  | CmdComment String
   | CmdExit
 
 newtype Script = Script [Command]

--- a/src/SMTLib2/PP.hs
+++ b/src/SMTLib2/PP.hs
@@ -156,11 +156,13 @@ instance PP Command where
       CmdGetUnsatCore   -> one "get-unsat-core"
       CmdGetInfo i      -> std "get-info" i
       CmdGetOption n    -> std "get-option" n
+      CmdComment s      -> vcat (map comment (lines s))
       CmdExit           -> one "exit"
     where mk x d = parens (text x <+> d)
           one x   = mk x empty
           std x a = mk x (pp a)
           fun x y as d = mk x (pp y <+> parens (fsep (map pp as)) <+> d)
+          comment s = text ";" <+> text s
 
 instance PP Script where
   pp (Script cs) = vcat (map pp cs)

--- a/test/Test2.hs
+++ b/test/Test2.hs
@@ -19,6 +19,7 @@ script = Script
   , CmdDeclareFun "x" [] (tBitVec 4)
   , CmdAssert (c "x" === bv 3 4)
   , CmdCheckSat
+  , CmdComment "hooray"
   , CmdExit
   ]
 


### PR DESCRIPTION
I made this change locally since it was useful in debugging generated scripts to have some indication of the origin of different commands in the final script.

This is the simplest way of representing such comments... A strictly more general representation would be something like `CmdCommented String [Command] String` so that a block of commands could be wrapped with, for example, a text editor's folding delimiters.