### PR TITLE
Apply fix for GHC 8.4.1 (with base-4.11)

### DIFF
--- a/smtLib.cabal
+++ b/smtLib.cabal
@@ -1,5 +1,5 @@
 Name:           smtLib
-Version:        1.0.8
+Version:        1.0.9
 License:        BSD3
 License-file:   LICENSE
 Author:         Iavor S. Diatchki

--- a/src/SMTLib1/PP.hs
+++ b/src/SMTLib1/PP.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE Safe #-}
 module SMTLib1.PP where
 
+import Prelude hiding ((<>))
 import SMTLib1.AST
 import Text.PrettyPrint
 

--- a/src/SMTLib2/PP.hs
+++ b/src/SMTLib2/PP.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE Safe #-}
 module SMTLib2.PP where
 
+import Prelude hiding ((<>))
 import SMTLib2.AST
 import Text.PrettyPrint
 import Numeric


### PR DESCRIPTION
This is needed to avoid errors of the form

```
src/SMTLib1/PP.hs:14:22: error:
    Ambiguous occurrence ‘<>’
    It could refer to either ‘Prelude.<>’,
                             imported from ‘Prelude’ at src/SMTLib1/PP.hs:2:8-17
                             (and originally defined in ‘GHC.Base’)
                          or ‘Text.PrettyPrint.<>’,
                             imported from ‘Text.PrettyPrint’ at src/SMTLib1/PP.hs:5:1-23
                             (and originally defined in ‘Text.PrettyPrint.HughesPJ’)
   |
14 |   pp (I x is) = pp x <> case is of
   |                      ^^
```


due to the Semigroup Monoid Proposal.